### PR TITLE
Add iOS App Store subscription compliance

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -26,7 +26,11 @@ The data controller is the **individual developer of Seriously (EU‑based priva
 - **Profile & Wellness Data.** Age, weight, height, dietary preferences or restrictions, calorie targets, and similar wellness details you choose to enter. Some entries may be considered **health‑related data**; they’re processed only with your explicit consent, which you give when entering them in the App.
 - **AI Chat Inputs.** The questions and messages you submit to the AI coach. Avoid sharing highly sensitive data.
 - **App & Device Data.** Logs about feature usage and basic device data (model, OS version, app version, and identifiers needed for functionality/troubleshooting).
-- **Subscription Data (if applicable).** If you subscribe to Premium features, I receive confirmation of your purchase, plan, and renewal status via Apple’s in‑app purchase system with the help of RevenueCat. I do **not** receive or store payment card details.
+- **Subscription & Payment Data.** If you subscribe to Premium features:
+  - **Purchase Information:** I receive confirmation of your purchase, subscription plan, renewal status, and purchase date via Apple's in-app purchase system through RevenueCat
+  - **Transaction Records:** Apple transaction IDs, receipt data, and subscription status for verification and customer support
+  - **Billing Information:** I do **not** receive, process, or store payment card details, billing addresses, or financial information - all payment processing is handled securely by Apple
+  - **Purchase History:** Records of subscription start dates, renewals, cancellations, and refunds for customer support and legal compliance
 
 I collect **only what’s needed** to provide and improve the App.
 
@@ -37,7 +41,7 @@ I collect **only what’s needed** to provide and improve the App.
 - **Provide & Personalize the Service.** Use profile/goals/chat inputs to tailor coaching and tracking features.
 - **AI‑Powered Responses.** Your chat inputs are sent securely to AI providers **(OpenAI and/or Google)** to generate responses.
 - **Account & Support.** Authenticate your login (Apple/Google), send critical service updates, and respond to support.
-- **Subscription Management (if used).** Verify subscription status (via RevenueCat) and unlock Premium features.
+- **Subscription & Payment Processing.** Verify subscription status, process renewals, handle subscription changes, manage access to Premium features, and maintain transaction records for customer support and legal compliance (via RevenueCat and Apple's systems).
 - **Improve & Secure the App.** Analyze aggregated usage (de‑identified where possible), fix bugs, and prevent abuse or fraud.
 - **Legal Compliance.** Comply with lawful requests and tax/transaction record‑keeping where applicable.
 
@@ -59,7 +63,7 @@ I will not use your data for purposes that are incompatible with the above witho
 To power features, I use a small number of service providers acting on my instructions as **processors**. I share only what’s necessary to provide the App, I do **not** sell your data, and I do **not** use advertising/behavioral tracking SDKs.
 
 - **AI providers (e.g., OpenAI, Google).** Your prompts (and minimal context) are sent to generate a reply. I do not include your direct contact details in prompts. Processing is subject to each provider’s terms; I do not control their systems.
-- **RevenueCat (subscriptions, if used).** Processes purchase receipts from Apple to determine subscription status. I do not receive your payment card details.
+- **RevenueCat (subscription management).** Processes Apple purchase receipts, manages subscription status verification, handles subscription analytics, and facilitates customer support for billing issues. I do not receive your payment card details through this service.
 - **Apple / Google (auth & app stores).** Governed by their terms when you sign in or purchase.
 
 Data may be processed in or transferred to countries outside the EU. Where this happens, I rely on appropriate safeguards and protect data in transit and at rest.
@@ -80,7 +84,7 @@ I **do not** use third‑party data for advertising or profiling, and I avoid co
 
 - **Account data** is kept while your account is active. Upon deletion or prolonged inactivity, it’s deleted or anonymized (subject to brief backup retention).
 - **Wellness entries & chat logs.** Kept so the App works (e.g., showing your history) and deleted on account deletion or upon your request. Not used for third‑party advertising.
-- **Subscription records** are kept while needed for service and legal obligations.
+- **Subscription & transaction records** are kept for as long as your subscription is active, plus additional time as required for customer support, dispute resolution, tax compliance, and legal obligations (typically 7 years for financial records). Apple retains its own transaction records per their policies.
 
 ---
 

--- a/terms.md
+++ b/terms.md
@@ -63,9 +63,40 @@ I do **not** undertake to monitor user content, but I may remove content or susp
 
 ---
 
-## Subscriptions & Purchases (if offered)
+## Subscriptions & Purchases
 
-Purchases use **Apple’s in‑app purchase** system. Apple bills your Apple ID; manage/cancel in your Apple ID settings. I don’t see your card details. RevenueCat helps verify subscription status. Trials, renewals, price changes, and refunds are handled per Apple policies. If payment fails, access to Premium may be suspended.
+### Auto-Renewable Subscriptions
+
+Seriously offers premium features through auto-renewable subscriptions purchased via Apple's in-app purchase system. By subscribing, you agree to the following terms:
+
+**Billing & Auto-Renewal:**
+- Payment will be charged to your Apple ID account at the confirmation of purchase
+- Subscriptions automatically renew unless auto-renew is turned off at least 24 hours before the end of the current period
+- Your account will be charged for renewal within 24 hours prior to the end of the current period
+- The cost of renewal will be the same price you initially paid for the subscription unless price changes are communicated in advance
+
+**Managing Subscriptions:**
+- You can manage and cancel your subscriptions by going to your Apple ID account settings after purchase
+- Auto-renewal may be turned off by going to your Apple ID Account Settings after purchase
+- No cancellation of the current subscription is allowed during the active subscription period
+
+**Free Trials:**
+- Free trials, if offered, allow you to experience premium features at no cost for a specified period
+- Any unused portion of a free trial period will be forfeited when you purchase a subscription
+- At the end of the free trial, your subscription will automatically begin and you will be charged the subscription price
+
+**Refunds:**
+- Refund requests must be submitted directly to Apple through the App Store
+- I do not process refunds directly as all billing is handled through Apple's systems
+- Refunds are subject to Apple's terms and conditions
+
+**Subscription Verification:**
+- RevenueCat is used to verify subscription status and unlock premium features
+- I do not receive or store your payment card details - all payment processing is handled by Apple
+
+**Access & Service Suspension:**
+- If payment fails or subscription expires, access to premium features may be suspended immediately
+- Your subscription data and progress will be preserved during temporary suspensions
 
 ---
 


### PR DESCRIPTION
## Summary
- Added comprehensive auto-renewable subscription terms to Terms of Service with Apple-required disclosures
- Updated Privacy Policy with detailed subscription and payment data handling requirements
- Included mandatory billing, cancellation, refund, and free trial policies per iOS App Store guidelines

## Legal Compliance
- ✅ Auto-renewal disclosure requirements (24-hour cancellation policy)
- ✅ Free trial forfeiture terms
- ✅ Apple billing system acknowledgment
- ✅ Payment data handling transparency
- ✅ Transaction record retention policies
- ✅ RevenueCat integration disclosure

## Recommendation
Use Apple's standard EULA rather than creating custom EULA - provides adequate protection for independent developer while reducing legal complexity.

🤖 Generated with [Claude Code](https://claude.ai/code)