### PR TITLE
Add Supabase disclosure to privacy policy and terms

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -6,7 +6,7 @@ permalink: /privacy
 
 # Seriously — Privacy Policy
 
-**Last updated:** August 9, 2025
+**Last updated:** October 5, 2025
 
 Seriously (the "App") is an iOS mobile app that provides AI‑powered diet coaching, calorie tracking, and nutrition tips. I respect your privacy and am committed to protecting your personal data. This Privacy Policy explains what information I collect, how it's used and shared, and your rights.
 
@@ -65,7 +65,8 @@ I will not use your data for purposes that are incompatible with the above witho
 
 To power features, I use a small number of service providers acting on my instructions as **processors**. I share only what’s necessary to provide the App, I do **not** sell your data, and I do **not** use advertising/behavioral tracking SDKs.
 
-- **AI providers (e.g., OpenAI, Google).** Your prompts (and minimal context) are sent to generate a reply. I do not include your direct contact details in prompts. Processing is subject to each provider’s terms; I do not control their systems.
+- **AI providers (e.g., OpenAI, Google).** Your prompts (and minimal context) are sent to generate a reply. I do not include your direct contact details in prompts. Processing is subject to each provider's terms; I do not control their systems.
+- **Supabase (backend infrastructure).** Provides secure database, authentication, and backend services to store and manage your account data, wellness entries, chat logs, and food photos. Data is encrypted in transit and at rest.
 - **RevenueCat (subscription management).** Processes Apple purchase receipts, manages subscription status verification, handles subscription analytics, and facilitates customer support for billing issues. I do not receive your payment card details through this service.
 - **Apple / Google (auth & app stores).** Governed by their terms when you sign in or purchase.
 

--- a/terms.md
+++ b/terms.md
@@ -6,7 +6,7 @@ permalink: /terms
 
 # Seriously — Terms of Service
 
-**Last updated:** August 9, 2025
+**Last updated:** October 5, 2025
 
 Welcome to Seriously! These Terms govern your use of the App, which is built and maintained by a **private individual** (not a company). By downloading or using the App, you agree to these Terms and the Privacy Policy. If you don’t agree, do not use the App.
 
@@ -118,7 +118,14 @@ Except for your content, the App, code, designs, and materials are owned by the 
 
 ## Third‑Party Services
 
-Links or integrations (e.g., Apple Health, articles) are governed by third‑party terms. I’m not responsible for their content or practices.
+The App uses third-party service providers to deliver functionality:
+
+- **AI providers (OpenAI, Google):** Power the AI coaching and food analysis features
+- **Supabase:** Provides backend infrastructure for secure data storage, authentication, and database services
+- **RevenueCat:** Manages subscription verification and billing support
+- **Apple/Google:** Handle authentication and in-app purchases
+
+Links or integrations (e.g., Apple Health, articles) are governed by third‑party terms. I'm not responsible for their content or practices.
 
 ---
 


### PR DESCRIPTION
## Summary
- Added Supabase to the list of third-party service providers in both privacy policy and terms of service
- Updated last modified dates to October 5, 2025
- Ensures complete disclosure of technical stack for App Store review compliance

## Changes
- **privacy.md**: Added Supabase under "AI and Third-Party Processors" section with description of backend infrastructure services
- **terms.md**: Added Supabase under "Third-Party Services" section with complete list of service providers

## Context
Addresses App Store review feedback requiring one-to-one match between privacy policy disclosures and the actual technical stack (OpenAI, Google, RevenueCat, Apple/Google auth, and Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)